### PR TITLE
POC CHANGE_DIVISION_REPUTATION

### DIFF
--- a/History Editor/HistoryLoader.cs
+++ b/History Editor/HistoryLoader.cs
@@ -299,6 +299,20 @@ namespace CM0102Patcher
             }
         }
 
+        public void UpdateDivisionReputation(int divisionID, int reputation)
+        {
+            for (int i = 0; i < club_comp.Count; i++)
+            {
+                if (club_comp[i].ID == divisionID)
+                {
+                    TComp divisionToUpdate = club_comp[i];
+                    // Based on types @see /SaveChanger/Structures.cs
+                    divisionToUpdate.ClubCompReputation = reputation;
+                    club_comp[i] = divisionToUpdate;
+                }
+            }
+        }
+
         public void Save(string indexFile, bool saveClubData = false, bool saveStaffData = false, bool saveNationData = false)
         {
             var dir = Path.GetDirectoryName(indexFile);

--- a/Patcher.cs
+++ b/Patcher.cs
@@ -309,7 +309,7 @@ namespace CM0102Patcher
                                                                  "CHANGECLUBDIVISION", "CHANGECLUBLASTDIVISION", "CHANGECLUBLASTPOSITION", "CHANGECLUBNATION", 
                                                                  "CHANGENATIONCOMPNAME", "CHANGENATIONCOMPCOLOR", "CLEARNATIONCOMPHISTORY", 
                                                                  "ADDNATIONCOMPHISTORY", "DELETECLUBCOMPHISTORY", "DELETENATIONCOMPHISTORY", "SHIFTNATIONCOMPHISTORY",
-                                                                 "CHANGENATIONCONTINENT", "REORDERDATA"
+                                                                 "CHANGENATIONCONTINENT", "REORDERDATA", "CHANGE_DIVISION_REPUTATION"
         };
 
         Dictionary<string, List<HexPatch>> GetCommands(IEnumerable<HexPatch> patch)
@@ -615,6 +615,28 @@ namespace CM0102Patcher
                         hl.UpdateClubsNation(tClub.ID, tNation.ID);
                     }
 
+                }
+
+                // CHANGE_DIVISION_REPUTATION
+                if (commandDictionary["CHANGE_DIVISION_REPUTATION"].Count > 0)
+                {
+                    foreach (var divisionReputationChange in commandDictionary["CHANGE_DIVISION_REPUTATION"])
+                    {
+                        var divisionName = divisionReputationChange.part1; // Consider that division "Name" is ID
+                        var newDivisionReputation = int.Parse(divisionReputationChange.part2);
+                        var division = hl.club_comp.FirstOrDefault(x => MiscFunctions.GetTextFromBytes(x.Name) == divisionName);
+
+                        if (divisionNameInDd != null) {
+                            if (0 < newDivisionReputation <= 20) { // Value should be moved to const
+                                PatcherForm.updatingForm.SetUpdateText(divisionReputationChange.command + " " + divisionName + " " + newDivisionReputation);
+                                hl.UpdateDivisionReputation(division.ID, newDivisionReputation);
+                            } else {
+                                Console.WriteLine("The reputation for Division '{0}' is incorrect. The value must be between 1 and 20 inclusive. You have provided the value '{1}'.", divisionName, divisionReputationChange.part2);
+                            }
+                        } else {
+                            Console.WriteLine("Division '{0}' in CHANGE_DIVISION_REPUTATION not found", divisionName);
+                        }
+                    }
                 }
 
                 // CHANGENATIONCOMPNAME


### PR DESCRIPTION
POC for the CHANGE_DIVISION_REPUTATION functionality

IMPORTANT
**This code has not been compiled, tested, and is written as is.**

The key question is in
https://github.com/nckstwrt/CM0102Patcher/pull/4/files#diff-378b76a976a9abfdbcf854c24e6583cf8dd588108b52e6b38d2d018a3307e748R632

Does
`var division = hl.club_comp.FirstOrDefault(x => MiscFunctions.GetTextFromBytes(x.Name) == divisionName);`
really return an object from which we can get the ID for
`hl.UpdateDivisionReputation(division.ID, newDivisionReputation);`

Cheers